### PR TITLE
Convert repository to minimalist static site generator for Vercel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,15 @@
 .env
 *.gdoc
 nul
+
+# Obsidian & Tools
+.obsidian/
+.smart-env/
+.smart-connections/
+.opencode/
+
+# Node
+node_modules/
+
+# Build Output
+dist/

--- a/build.js
+++ b/build.js
@@ -1,0 +1,136 @@
+const fs = require('fs-extra');
+const path = require('path');
+const { marked } = require('marked');
+
+const DIST_DIR = path.join(__dirname, 'dist');
+const SOURCE_DIRS = ['.', 'Marketing, ventas, IA'];
+
+// Slugify function: lowercase, no accents, hyphens for spaces/special chars
+function slugify(text) {
+    return text
+        .toString()
+        .normalize('NFD') // split accented characters into their base characters and diacritical marks
+        .replace(/[\u0300-\u036f]/g, '') // remove diacritical marks
+        .toLowerCase()
+        .trim()
+        .replace(/[^a-z0-9. ]/g, '') // remove non-alphanumeric except dots and spaces (to keep extensions for now)
+        .replace(/\s+/g, '-') // replace spaces with hyphens
+        .replace(/-+/g, '-'); // remove consecutive hyphens
+}
+
+function getSlugifiedFilename(filename) {
+    const ext = path.extname(filename);
+    const base = path.basename(filename, ext);
+    return slugify(base) + (ext === '.md' ? '.html' : ext.toLowerCase());
+}
+
+const htmlTemplate = (title, content) => `
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>${title}</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/water.css">
+    <style>
+        body {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            line-height: 1.6;
+        }
+        img {
+            max-width: 100%;
+            height: auto;
+            display: block;
+            margin: 1em auto;
+        }
+        nav {
+            margin-bottom: 2em;
+            padding-bottom: 1em;
+            border-bottom: 1px solid #ccc;
+        }
+    </style>
+</head>
+<body>
+    <nav>
+        <a href="index.html">Inicio</a>
+    </nav>
+    <article>
+        ${content}
+    </article>
+</body>
+</html>
+`;
+
+async function build() {
+    try {
+        // 1. Prepare dist directory
+        await fs.emptyDir(DIST_DIR);
+
+        const mdFiles = [];
+        const imageFiles = [];
+
+        // 2. Scan directories
+        for (const dir of SOURCE_DIRS) {
+            const fullDir = path.join(__dirname, dir);
+            if (!await fs.pathExists(fullDir)) continue;
+
+            const items = await fs.readdir(fullDir);
+            for (const item of items) {
+                const itemPath = path.join(fullDir, item);
+                const stat = await fs.stat(itemPath);
+
+                if (stat.isFile()) {
+                    const ext = path.extname(item).toLowerCase();
+                    if (ext === '.md') {
+                        mdFiles.push({ path: itemPath, name: item });
+                    } else if (['.png', '.jpg', '.jpeg', '.webp', '.gif', '.svg'].includes(ext)) {
+                        imageFiles.push({ path: itemPath, name: item });
+                    }
+                }
+            }
+        }
+
+        // 3. Process Images (copy with slugified name)
+        for (const img of imageFiles) {
+            const slugName = getSlugifiedFilename(img.name);
+            await fs.copy(img.path, path.join(DIST_DIR, slugName));
+        }
+
+        // 4. Process Markdown files
+        for (const md of mdFiles) {
+            let content = await fs.readFile(md.path, 'utf-8');
+
+            // Remove Frontmatter
+            content = content.replace(/^---[\s\S]*?---/, '');
+
+            // Process Image Wikilinks: ![[Image Name.png]] or ![[Image Name.png|caption]]
+            content = content.replace(/!\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g, (match, fileName, alt) => {
+                const slugName = getSlugifiedFilename(fileName.trim());
+                return `<img src="${slugName}" alt="${alt || fileName.trim()}">`;
+            });
+
+            // Process Note Wikilinks: [[Note Name]] or [[Note Name|Alias]]
+            content = content.replace(/\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g, (match, noteName, alias) => {
+                const slugName = getSlugifiedFilename(noteName.trim().endsWith('.md') ? noteName.trim() : noteName.trim() + '.md');
+                const text = alias || noteName;
+                return `<a href="${slugName}">${text}</a>`;
+            });
+
+            const htmlContent = marked.parse(content);
+            const title = path.basename(md.name, '.md');
+            const finalHtml = htmlTemplate(title, htmlContent);
+
+            const outFilename = getSlugifiedFilename(md.name);
+            await fs.writeFile(path.join(DIST_DIR, outFilename), finalHtml);
+        }
+
+        console.log('Build complete! Static site generated in dist/');
+    } catch (err) {
+        console.error('Error during build:', err);
+        process.exit(1);
+    }
+}
+
+build();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,69 @@
+{
+  "name": "obsidian-digital-garden",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "obsidian-digital-garden",
+      "version": "1.0.0",
+      "dependencies": {
+        "fs-extra": "^11.2.0",
+        "marked": "^12.0.0"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/marked": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
+      "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "obsidian-digital-garden",
+  "version": "1.0.0",
+  "description": "Minimalist static site generator for Obsidian notes",
+  "main": "build.js",
+  "scripts": {
+    "build": "node build.js"
+  },
+  "dependencies": {
+    "fs-extra": "^11.2.0",
+    "marked": "^12.0.0"
+  }
+}


### PR DESCRIPTION
This Pull Request transforms the repository into a self-contained static site generator (SSG) specifically tailored for Obsidian notes. 

Key changes:
- **Build System**: Introduced a custom `build.js` script that processes Markdown files from the root and the `Marketing, ventas, IA/` directory.
- **Wikilink & Image Support**: Added support for Obsidian-style Wikilinks `[[Note]]` and image embeds `![[Image.png]]`, automatically converting them to slugified HTML links and tags.
- **Slugification**: Implemented a robust slugification function to ensure all URLs are clean, lowercase, and free of special characters or accents.
- **Minimalist Frontend**: Integrated `water.css` (classless CSS) via CDN to provide a clean, responsive design with automatic dark mode.
- **Vercel Readiness**: Configured `package.json` so that Vercel can automatically build the site using `npm run build`.
- **Repository Cleanup**: Updated `.gitignore` to keep the repository clean of Obsidian metadata and build artifacts.
- **Structure**: Flattened the note structure into a single `dist/` folder to support aesthetic URLs (e.g., `domain.com/note-name`).

---
*PR created automatically by Jules for task [7543398368036998996](https://jules.google.com/task/7543398368036998996) started by @pablozamit*